### PR TITLE
Ntd1hc/feat/maintain package dependencies

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -37,29 +37,10 @@ jobs:
             password: ${{ secrets.PYPI_API_TOKEN }} # This token should be created in Settings > Secrets > Actions
             # repository_url: https://test.pypi.org/legacy/ # Use this for testing to upload the distribution to test.pypi
 
-        - name: Create GitHub Release
-          id: create_release
-          uses: actions/create-release@v1.1.4
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        - name: Create/Update GitHub Release
+          id: create_update_release
+          uses: ncipollo/release-action@v1
           with:
-            tag_name: ${{ github.ref }}
-            release_name: ${{ github.ref }}
-            draft: false
-            prerelease: false
-
-        - name: Get Asset name
-          run: |
-            export PKG=$(ls dist/ | grep tar)
-            set -- $PKG
-            echo "name=$1" >> $GITHUB_ENV
-        - name: Upload Release Asset (sdist) to GitHub
-          id: upload-release-asset
-          uses: actions/upload-release-asset@v1.0.2
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            upload_url: ${{ steps.create_release.outputs.upload_url }}
-            asset_path: dist/${{ env.name }}
-            asset_name: ${{ env.name }}
-            asset_content_type: application/zip
+            allowUpdates: true
+            omitNameDuringUpdate: true
+            artifacts: dist/*

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -24,7 +24,7 @@ jobs:
           run: |
             sudo apt-get install -y pandoc
             sudo apt-get install -y texlive-latex-*
-            python -m pip install --upgrade build twine colorama pypandoc wheel dotdict genpackagedoc
+            python -m pip install --upgrade build twine wheel genpackagedoc dotdict
 
         - name: Build source and wheel distributions
           run: |

--- a/config/repository_config.json
+++ b/config/repository_config.json
@@ -13,7 +13,7 @@
    "DEVELOPMENTSTATUS" : "Development Status :: 4 - Beta",
    "INTENDEDAUDIENCE" : "Intended Audience :: Developers",
    "TOPIC" : "Topic :: Software Development",
-   "INSTALLREQUIRES" : ["pypandoc","colorama","GenPackageDoc"],
+   "INSTALLREQUIRES" : ["dotdict"],
    "PACKAGEDATA" : ["*.pdf"],
    "PACKAGEDOC" : "./packagedoc"
 }


### PR DESCRIPTION
Hi Thomas,

I have updated dependencies for build pipeline and package accordingly as we discussed.
Besides, workflow is also updated to attach built `*.whl` file as Release Asset.

Please review and merge this PR first. I am updating other repos accordingly.
As soon as this package is available on PyPI, other repos can remove `dotdict` from build dependencies.

Thank you,
Ngoan